### PR TITLE
Don't look for links in PDFs, and ignore tel: schema links

### DIFF
--- a/linkcheck.go
+++ b/linkcheck.go
@@ -75,6 +75,7 @@ func href(n *html.Node) string {
 var invalidProtos = []string{
 	"mailto:",
 	"javascript:",
+	"tel:",
 }
 
 func excludeLink(ref string) bool {


### PR DESCRIPTION
When running this against qpp.cms.gov, it looks like it was going inside of PDFs searching for links, and somehow it found some!